### PR TITLE
Fix dataset loading with transforms

### DIFF
--- a/src/transforms.py
+++ b/src/transforms.py
@@ -56,6 +56,8 @@ class ToTensor(object):
 
     def __call__(self, sample):
         image, label = sample['image'], sample['label']
+        if len(label.shape) == 0:
+            label = np.asarray([label])
 
         label = np.expand_dims(label, axis=1).astype(np.float32)
 


### PR DESCRIPTION
Fixes cell `[6]`:
```
# With `get_transform` function we extract cropped, rescaled and augmented regions of interest
# This allows us to experiment with different areas of a radiograph. See the paper referenced in README
# We also normalize labels by demeaning and rescaling to (120, 120), see `normalize_target` function

# Let's crop just wrist area
crop_center = 1600, 800
crop_size = 500, 1000
scale = 0.25
crop_dict = {'crop_center': crop_center, 'crop_size': crop_size}
train_transform = get_transform(augmentation=True, crop_dict=crop_dict, scale=scale)

boneage_dataset = BoneAgeDataset(bone_age_frame=bone_age_frame, root=image_root,
                                 transform=train_transform, target_transform=normalize_target)
nimages = 12
plot_radiographs(boneage_dataset, nimages)
```
Which fails with error:
```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-6-ffb04e4e8ce3> in <module>
     13                                  transform=train_transform, target_transform=normalize_target)
     14 nimages = 12
---> 15 plot_radiographs(boneage_dataset, nimages)

<ipython-input-4-3adcb01948bd> in plot_radiographs(dataset, nimages, predictions)
     18 
     19     figsize = 6
---> 20     aspect_ratio = image.shape[0] / image.shape[1]
     21     fig.set_figheight(aspect_ratio * nrows * figsize)
     22     fig.set_figwidth(ncols * figsize)

UnboundLocalError: local variable 'image' referenced before assignment

<Figure size 432x288 with 0 Axes>
```

Thanks @atselousov for help.