### PR TITLE
Bump deployment dependencies, update deployment job

### DIFF
--- a/.neuro/live.yaml
+++ b/.neuro/live.yaml
@@ -35,16 +35,16 @@ volumes:
 
 images:
   train:
-    ref: image:${{ flow.project_id }}:v2
+    ref: image:${{ flow.project_id }}:v3
     dockerfile: ${{ flow.workspace }}/docker/train.dockerfile
     context: ${{ flow.workspace }}/
-    build_preset: gpu-k80-small-p
+    build_preset: gpu-small-p
   cpu_worker:
     ref: image:${{ flow.project_id }}/cpu_worker:v1
     dockerfile: ${{ flow.workspace }}/docker/cpu-worker.dockerfile
     context: ${{ flow.workspace }}/
   inference:
-    ref: image:${{ flow.project_id }}/inference:21.1.23
+    ref: image:${{ flow.project_id }}/inference:21.4.13
     dockerfile: ${{ flow.workspace }}/seldon_deployment/seldon.Dockerfile
     context: ${{ flow.workspace }}/
     build_preset: cpu-large
@@ -442,8 +442,8 @@ jobs:
   deploy_inference_platform:
     image: ${{ images.inference.ref }}
     name: ${{ flow.title }}-test-inference
-    preset: cpu-small
-    http_port: 5000
+    preset: gpu-k80-small-p
+    http_port: 9000
     http_auth: False
     life_span: 5h
     detach: True
@@ -469,7 +469,7 @@ jobs:
     env:
       DATA_DIR: ${{ volumes.remote_dataset.mount }}/bone-age-tiny/
       PYTHONPATH: ${{ volumes.src.mount }}/..
-    # Job URI: https://ml-recipe-bone-age-test-inference--yevheniisemendiak.jobs.neuro-compute.org.neu.ro/predict
+    # Job URI: https://ml-recipe-bone-age-test-inference--yevheniisemendiak.jobs.neuro-compute.org.neu.ro/api/v1.0/predictions
     # Seldon URI: https://seldon.onprem-poc.org.neu.ro/seldon/seldon/my-model/api/v1.0/predictions
     cmd: |
       -f ${{ volumes.src.mount }}/locust.py --users 1 --spawn-rate 1 --web-port 8080

--- a/docker/train.dockerfile
+++ b/docker/train.dockerfile
@@ -1,15 +1,14 @@
 FROM pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
 
-COPY apt.txt .
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -qq update \
     && apt-get -qq install --no-install-recommends \
-        libsm6 \
-        libxext6 \
-        openssh-client \
-        git \
-        wget \
-        unzip \
+    libsm6 \
+    libxext6 \
+    openssh-client \
+    git \
+    wget \
+    unzip \
     && apt-get -qq clean \
     && apt-get -qq autoremove \
     && rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ torch==1.7.1
 numpy>=1.17.*
 matplotlib>=3.1.*
 torchvision==0.8.2
-mlflow[extras]==1.13.1
-dvc==1.10.1
+mlflow[extras]>=1.13.1
+dvc>=1.10.1
 jupyter==1.0.0

--- a/seldon_deployment/seldon.Dockerfile
+++ b/seldon_deployment/seldon.Dockerfile
@@ -1,13 +1,14 @@
-FROM seldonio/seldon-core-s2i-python3:0.18
+FROM seldonio/seldon-core-s2i-python3:1.7.0-dev
 ENV MODEL_NAME="seldon_deployment.seldon_model.SeldonModel" \
     API_TYPE="REST" \
     SERVICE_TYPE="MODEL" \
     PERSISTENCE="0"
 # Copying in source code
-COPY . /tmp/src
+COPY . /microservice
 # Assemble script sourced from builder image based on user input or image metadata.
 # If this file does not exist in the image, the build will fail.
-RUN /s2i/bin/assemble
+RUN cd /microservice && \
+    pip install --no-cache-dir --ignore-installed -r requirements.txt
 # Run script sourced from builder image based on user input or image metadata.
 # If this file does not exist in the image, the build will fail.
 CMD /s2i/bin/run


### PR DESCRIPTION
Since our current deployment was outdated in terms of dependencies: the Seldon-core was ancient and caused dependencies errors with MLFlow and DVC libs.
